### PR TITLE
Don't echo the Datadog API key

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -16,7 +16,6 @@ PAYLOAD="{ \"title\": \"${BUILDKITE_PLUGIN_DATADOG_EVENT_TITLE}\", \"priority\":
 API_END_POINT="https://app.datadoghq.com/api/v1/events?api_key=${!BUILDKITE_PLUGIN_DATADOG_EVENT_ENV}"
 
 echo "Event payload: $PAYLOAD"
-echo "Datadog api endpoint: $API_END_POINT"
 
 curl -X POST -H "Content-type: application/json" -d "$PAYLOAD" "$API_END_POINT" 2>&1 | grep 'status":"ok"'
 


### PR DESCRIPTION
This sends the API key in plaintext to Buildkite. This can be easily seen by inspecting the build log of this plugin in the `Sending deployment events to datadog` section.

Any user of version v0.0.4 should consider their Datadog API key compromised and rotate it as soon as this commit has been released.